### PR TITLE
More robust, but still backwards-compatible, evaluate()

### DIFF
--- a/lib/numeric.ly.js
+++ b/lib/numeric.ly.js
@@ -80,7 +80,10 @@ var numeric = {
 
   //evaluate function at val (func passed as a string)
   evaluate: function(func, val) {
-    return parseFloat(eval("with(Math){var x = " + val + ";" + func+'};'));
+    if(typeof func == 'string') {
+      return Math[func.substring(0,func.indexOf('('))](val);
+    }
+    return func(val);
   },
 
 /*-----------------------------------------------------------------------------*/


### PR DESCRIPTION
Using Math and string function names in evaluate() will prove limiting, imo, mainly because it means custom functions (not part of Math) can't be evaluated, which is a big loss. For instance, it means there's no way for me to pass in my own function and find its limit. Also eval() is slow and with isn't allowed in ES5 strict.

This version allows (really prefers) any function to be passed in as a function object, but uses a type check to support the earlier API.

If possible though, I'd probably drop that API all together.
