### PR TITLE
mocha should not be a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "numbers",
     "statistics"
   ],
-  "dependencies": {
+  "devDependencies": {
     "mocha": "~1.5.0"
   },
   "scripts": {


### PR DESCRIPTION
Moved mocha from dependencies to devDependencies so mocha isn't installed when installing numbers from npm
