### PR TITLE
Faster prime calculation with Math.sqrt

### DIFF
--- a/lib/numbers/prime.js
+++ b/lib/numbers/prime.js
@@ -11,17 +11,14 @@ prime.simple = function (val) {
   if (val === 1) return false;
   else if (val === 2) return true;
   else if (val !== undefined) {
-    var start = 2;
-    var result = true;
-    while (start < val) {
+    var start = 1;
+    var valSqrt = Math.ceil(Math.sqrt(val));
+    while (++start <= valSqrt) {
       if (val % start === 0) {
-        result = false;
-        break;
-      } else {
-        start++;
+        return false;
       }
     }
-    return result;
+    return true;
   }
 };
 

--- a/test/prime.test.js
+++ b/test/prime.test.js
@@ -7,10 +7,18 @@ suite('numbers', function() {
   console.log('\n\n\033[34mTesting Prime Number Mathematics\033[0m');
 
   test('should be able to determine if a number is prime or not', function(done) {
-    assert.equal(false, prime.simple(1));
-    assert.equal(true, prime.simple(2));
-    assert.equal(true, prime.simple(17));
-    done()
+    assert.equal(false, prime.simple(1), "1 should not be prime");
+    assert.equal(true,  prime.simple(2), "2 should be prime");
+    assert.equal(false, prime.simple(4), "4 should not be prime");
+    assert.equal(true,  prime.simple(17), "17 should be prime");
+    assert.equal(false, prime.simple(18), "18 should not be prime");
+    assert.equal(false, prime.simple(25), "25 should not be prime");
+    assert.equal(false, prime.simple(838), "838 should not be prime");
+    assert.equal(true,  prime.simple(839), "839 should be prime");
+    assert.equal(false, prime.simple(3007), "3007 should not be prime");
+    assert.equal(true,  prime.simple(3733), "3733 should be prime");
+    assert.equal(true,  prime.simple(999983), "999983 should be prime");
+    done();
   });
 
 });


### PR DESCRIPTION
When checking prime numbers, rather than evaluating all integers up to the target number, you can stop evaluating at the square root of the target number.

Any pair of factors for a number must contain a factor equal or less than the square root of the number.

Here is the performance difference with this change. http://jsperf.com/prime-with-sqrt 1024 times faster for calculating 999983!
