### PR TITLE
Change the distance (delta) between two points to calculate a derivative at a point.

### DIFF
--- a/lib/numbers/calculus.js
+++ b/lib/numbers/calculus.js
@@ -11,8 +11,8 @@ var calculus = exports;
  * @return {Number} result
  */
 calculus.pointDiff = function (func, point) {
-  var a = func(point - Number.MIN_VALUE);
-  var b = func(point + Number.MIN_VALUE);
+  var a = func(point - 1e-15);
+  var b = func(point + 1e-15);
 
   return (b - a) / (Number.MIN_VALUE*2);
 };


### PR DESCRIPTION
Using two points at distance `2*Number.MIN_VALUE` won't work, as `a +/- Number.MIN_VALUE = a`

This commit uses `1e-15` instead of `Number.MIN_VALUE`.

That's the highest precision we can get. without using an external library in javascript (possible option is to use bignum lib)
