### PR TITLE
Quantile function, median multidigit bugfix

### DIFF
--- a/lib/numbers/statistic.js
+++ b/lib/numbers/statistic.js
@@ -21,15 +21,7 @@ statistic.mean = function (arr) {
  * @return {Number} median value
  */
 statistic.median = function (arr) {
-  var sorted = arr.slice(0);
-  sorted.sort();
-  var count = sorted.length;
-  var middle;
-  if (count % 2 === 0) {
-    return (sorted[count/2] + sorted[(count/2 - 1)])/2;
-  } else {
-    return sorted[Math.floor(count / 2)];
-  }
+  return statistic.quantile(arr, 1, 2);
 };
 
 

--- a/test/statistic.test.js
+++ b/test/statistic.test.js
@@ -13,8 +13,8 @@ suite('numbers', function() {
   });
 
   test('median should return middle value in array for a sorted array with an odd number of values', function(done) {
-    var res1 = statistic.median([0, 1, 2]);
-    assert.equal(1, res1);
+    var res1 = statistic.median([0, 2, 15]);
+    assert.equal(2, res1);
     done();
   });
 


### PR DESCRIPTION
### Quantile function

`quantile(array, k, q)` computes the kth q-quantile of an unsorted array as defined in the [relevant Wikipedia entry](http://en.wikipedia.org/wiki/Quantile#Quantiles_of_a_population). It does not mutate the array. For example, the lower quartile (1st 4-quantile) of {3, 6, 7, 8, 8, 10, 13, 15, 16, 20} is 7.
### Median multidigit bugfix

While testing the quantile function, I noticed that the array sort wasn't happening correctly in the median function. Previously, `median([0, 2, 15])` returned 15. [According to MDN](https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Array/sort), sorting an array using `sorted.sort()` sorts alphabetically, so the sorted array became `[0, 15, 2]`. One of the tests for median has been updated to catch this. The solution was to pass a compare function:

```
sorted.sort(function (a, b) { return a - b; });
```

This will numerically sort the array to be in the correct order `[0, 2, 15]`. Rather than having nearly-duplicate code, the easiest way to fix this was to make `median(arr)` internally call the logically-equivalent `quantile(arr, 1, 2)`.
### Proposed quantile wrappers

It might be useful to add two additional functions, `quartile()` and `percentile()`, since these are both common statistical measurements.
