### PR TITLE
Explore using matrix transform in new Matrix type

### DIFF
--- a/lib/types/matrix.js
+++ b/lib/types/matrix.js
@@ -142,6 +142,30 @@ Matrix.prototype.add = function (add) {
 };
 
 /**
+* Rotate a two dimensional vector by degree.
+*
+* @param {Number} degree
+* @param {String} direction - clockwise or counterclockwise
+* @return {Matrix} 2-d matrix
+*/
+Matrix.prototype.rotate = function degree, direction) {
+  if (data.length === 2) {
+    var negate = direction === "clockwise" ? -1 : 1;
+    var radians = degree * (Math.PI / 180);
+
+    var transformation = [
+      [Math.cos(radians), -1*negate*Math.sin(radians)],
+      [negate*Math.sin(radians), Math.cos(radians)]
+    ];
+
+    this.data = matrix.multiply(transformation, this.data);
+    return this;
+  } else {
+    throw new Error('Only two dimensional matrices currently supported');
+  }
+};
+
+/**
  * Evaluate determinate of matrix.  Expect speed
  * degradation for matrices over 4x4. 
  *


### PR DESCRIPTION
In reference to [comment](https://github.com/sjkaliski/numbers.js/pull/48#issuecomment-11396663). So maybe something like this instead?

Matrix class makes the fluent interface easier to implement (that is where I was heading with breaking out the transform) so yeah now I think just adding the transforms in as methods on the Matrix class make sense.

If this makes sense I will implement the rest and add tests, and close the other pull request.
