### PR TITLE
Added SquareMatrix, determinant (accurate past 4x4)

### DIFF
--- a/lib/numbers/linear.js
+++ b/lib/numbers/linear.js
@@ -1,5 +1,6 @@
 var linear = exports;
 
 //export
-linear.Matrix = require('../types/matrix').Matrix;
-linear.Vector = require('../types/vector').Vector;
+linear.Matrix       = require('../types/matrix').Matrix;
+linear.SquareMatrix = require('../types/matrix').SquareMatrix;
+linear.Vector       = require('../types/vector').Vector;

--- a/lib/types/matrix.js
+++ b/lib/types/matrix.js
@@ -502,44 +502,6 @@ Matrix.prototype.undo = function () {
 }
 
 /**
- * Evaluate determinant of matrix.  Expect speed
- * degradation for matrices over 4x4. 
- *
- * @return {Number} determinant
- */
-Matrix.prototype.determinant = function() {
-  
-  if(this.colCount !== this.rowCount) {
-    throw new Error("Not a square matrix.");
-  }
-
-  if(this.rowCount === 1) {
-    return this.data[0][0];
-  }
-  else if (this.rowCount === 2) {
-    return this.data[0][0] * this.data[1][1] - this.data[0][1] * this.data[1][0];
-  }
-
-  var det = 0,
-      row, col,
-      diagLeft, diagRight;
-
-  for(col=0; col < this.colCount; col++) {
-    
-    diagLeft = this.data[0][col];
-    diagRight = this.data[0][col];
-
-    for(row=1; row < this.rowCount; row++) {
-      diagRight *= this.data[row][(((col + row) % this.colCount) + this.colCount) % this.colCount];
-      diagLeft *= this.data[row][(((col - row) % this.colCount) + this.colCount) % this.colCount];
-    }
-    det += diagRight - diagLeft;
-  }
-
-  return det;
-};
-
-/**
  * Return a copy ("clone") of this Matrix
  * @return {Matrix} The clone
  */ 
@@ -592,5 +554,112 @@ Matrix.isMatrix = function(arg) {
   return true;
 }
 
+
+/**
+ * Pretty print the matrix to console.
+ * Uses tabs.
+ */
+Matrix.prototype.print = function() {
+  for (var i = 0; i < this.getRowCount(); i++) {
+    var row = "";
+    for (var j = 0; j < this.getColumnCount(); j++) {
+      row += this.get(i,j) + "\t";
+    }
+    console.log(row);
+  }
+}
+
+/**
+ * Get the determinant. Try "casting" to a square matrix first.
+ *
+ * @return {Number} determinant.
+ */
+Matrix.prototype.determinant = function() {
+  if (this.getRowCount() === this.getColumnCount()) {
+    return (new SquareMatrix(this.data)).determinant();
+  } else {
+    throw new Error("Not a square matrix");
+  }
+}
+
+/**
+ * Remove row at index k.
+ *
+ * @return {Matrix} this matrix with row k removed.
+ */
+Matrix.prototype.removeRow = function(k) {
+  var newData = [];
+  for (var i = 0, len = this.getRowCount(); i < len; i++) {
+    if (i != k) {
+      newData.push(this.data[i]);
+    }
+  }
+  this.rowCount--;
+  this.data = newData;
+  return this;
+}
+
+/**
+ * Remove column at index k.
+ *
+ * @return {Matrix} this matrix with column k removed.
+ */
+Matrix.prototype.removeColumn = function(k) {
+  var newData = [];
+  for (var i = 0, len = this.getRowCount(); i < len; i++) {
+    var row = [];
+    for (var j = 0, len2 = this.getColumnCount(); j < len2; j++) {
+      if (j != k) {
+        row.push(this.getElement(i,j));
+      }  
+    }
+    newData.push(row);
+  }
+  this.colCount--;
+  this.data = newData;
+  return this;
+}
+
+
+// =============================================================================
+
+/** Instantiate a new square matrix. */
+var SquareMatrix = function(data) {
+  Matrix.call(this, data);
+}
+
+/** "Inherit" abilities and members of Matrix. */
+SquareMatrix.prototype = new Matrix();
+
+/** Set SquareMatrix constructor to SquareMatrix. */
+SquareMatrix.prototype.constructor = SquareMatrix;
+
+/**
+ * Recursively evaluate determinant of matrix.  Expect speed
+ * degradation for matrices over 4x4. 
+ *
+ * @return {Number} determinant
+ */
+SquareMatrix.prototype.determinant = function() {
+  var det = 0;
+
+  if (this.getRowCount() === 1) {
+    det = this.getElement(0,0);
+  } else if (this.getRowCount() === 2) {
+    det = this.getElement(0,0) * this.getElement(1,1) - this.getElement(1,0) * this.getElement(0,1);
+  } else {
+    for (var h = 0; h < this.getColumnCount(); h++) {
+      det += Math.pow(-1, h) * this.getElement(0,h) * this.clone()
+                                                   .removeRow(0)
+                                                   .removeColumn(h)
+                                                   .determinant();
+    }
+  }
+
+  return det;
+};
+
+
 //export
-exports.Matrix = Matrix;
+exports.Matrix       = Matrix;
+exports.SquareMatrix = SquareMatrix;

--- a/test/matrix-type.test.js
+++ b/test/matrix-type.test.js
@@ -2,6 +2,7 @@ var assert = require('assert');
 var numbers = require('../index.js');
 var matrix = numbers.matrix;
 var Matrix = numbers.linear.Matrix;
+var SquareMatrix = numbers.linear.SquareMatrix;
 
 suite('numbers', function() {
 
@@ -511,6 +512,48 @@ suite('numbers', function() {
     var res = Matrix.identity(3).getData();
 
     assert.deepEqual(identity, res);
+    done();
+  });
+
+
+  test('should test the determinant of a square matrix', function(done) {
+    var squareMatrix = new SquareMatrix(
+      [[3, -1, 0.2, 2],
+      [3, 1, 5, 1],
+      [6, 3, -5, 0],
+      [7, 7, 7, 1]]
+    );
+
+    var res = squareMatrix.determinant();
+    assert.equal(-247.2, res);
+    done();
+  });
+
+  test('should remove a row correctly', function(done) {
+    var m = new Matrix([
+      [1, 2, 0],
+      [1, 1, 0],
+      [0, 2, 1]
+    ]);
+
+    m.removeRow(1);
+    assert.equal(2, m.getRowCount());
+    assert.equal(3, m.getColumnCount());
+
+    done();
+  });
+
+  test('should remove a column correctly', function(done) {
+    var m = new Matrix([
+      [1, 2, 0, 2],
+      [1, 1, 0, 2],
+      [0, 2, 1, 15]
+    ]);
+
+    m.removeColumn(3);
+    assert.equal(3, m.getRowCount());
+    assert.equal(3, m.getColumnCount());
+
     done();
   });
 


### PR DESCRIPTION
Hey all, made some changes:
1. I added SquareMatrix. To calculate the determinant, it checks if we can "downcast" to SquareMatrix, then calls <code>determinant()</code> on <code>this</code>.
2. Our existing implementation of <code>determinant()</code> was not correct. [It evaluated to around 13 for this matrix](http://www.wolframalpha.com/input/?i=determinant+of%5B%5B3%2C+-1%2C+0.2%2C+2%5D%2C+%5B3%2C+1%2C+5%2C+1%5D%2C+%5B6%2C+3%2C+-5%2C+0%5D%2C+%5B7%2C+7%2C+7%2C+1%5D%5D). This commit should fix it, however note it employs recursion.
3. I implemented <code>removeRow(k)</code> and <code>removeColumn(k)</code>.

These changes comes with tests that pass.
