### PR TITLE
Bug fix from issue #81

### DIFF
--- a/lib/numbers/basic.js
+++ b/lib/numbers/basic.js
@@ -52,8 +52,11 @@ basic.sum = function (arr) {
  */
 basic.subtraction = function (arr) {
   if (Object.prototype.toString.call(arr) === '[object Array]') {
-    var total = arr[arr.length - 1];
-    for (var i = arr.length - 2; i >= 0; i--) {
+    var total = arr[0];
+    if (typeof(total) !== 'number') {
+      throw new Error('All elements in array must be numbers');
+    }
+    for (var i = 1, length = arr.length; i < length; i++) {
       if (typeof(arr[i]) === 'number') {
         total -= arr[i];
       } else {
@@ -75,6 +78,9 @@ basic.subtraction = function (arr) {
 basic.product = function (arr) {
   if (Object.prototype.toString.call(arr) === '[object Array]') {
     var total = arr[0];
+    if (typeof(total) !== 'number') {
+      throw new Error('All elements in array must be numbers');
+    }
     for (var i = 1, length = arr.length; i < length; i++) {
       if (typeof(arr[i]) === 'number') {
         total = total * arr[i];

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -35,7 +35,7 @@ suite('numbers', function() {
 
   // basic.substraction
   test('subtraction should return the difference of items in an array', function (done) {
-    assert.equal(0, basic.subtraction([0, 1, 2, 3]));
+    assert.equal(2, basic.subtraction([5, 3, 1, -1]));
     done();
   });
 
@@ -53,6 +53,16 @@ suite('numbers', function() {
     assert.throws(
       function() {
         basic.subtraction(["test", 1, 1, 2]);
+      },
+      /All elements in array must be numbers/
+    );
+    done();
+  });
+
+  test('subtraction should throw an exception last element is not a number', function (done) {
+    assert.throws(
+      function() {
+        basic.subtraction([1, 1, 2, "test"]);
       },
       /All elements in array must be numbers/
     );
@@ -80,6 +90,16 @@ suite('numbers', function() {
     assert.throws(
       function() {
         basic.product([1, 2, "error"]);
+      },
+      /All elements in array must be numbers/
+    );
+    done();
+  });
+
+  test('product should throw an exception when given anything objects other than numbers', function (done) {
+    assert.throws(
+      function() {
+        basic.product(["error", 1, 2]);
       },
       /All elements in array must be numbers/
     );


### PR DESCRIPTION
**Original**

[Issue #81](https://github.com/sjkaliski/numbers.js/issues/81)

**Changes**
- `basic.subtraction` now behaves like as described by the function documentation
- `basic.subtraction` checks all elements in the array for incorrect types
- `basic.product` checks all elements in the array for incorrect types
