### PR TITLE
Improved square matrix detection

### DIFF
--- a/lib/numbers/matrix.js
+++ b/lib/numbers/matrix.js
@@ -47,9 +47,12 @@ matrix.deepCopy = function(arr) {
  */
 matrix.isSquare = function(arr) {
   var rows = arr.length;
-  var cols = arr[0].length;
-  
-  return rows === cols;
+
+  for (var i = 0, row; row = arr[i]; i++) {
+    if (row.length != rows) return false;
+  }
+
+  return true;
 };
 
 /**

--- a/test/matrix.test.js
+++ b/test/matrix.test.js
@@ -26,6 +26,9 @@ suite('numbers', function() {
   test('should be able to tell if a matrix is square', function(done) {
     assert.equal(matrix.isSquare([[1,2],[3,4]]), true);
     assert.equal(matrix.isSquare([[1,2,3],[4,5,6]]), false);
+    assert.equal(matrix.isSquare([[1,2,3], [4,5,6], [7,8,9]]), true);
+    assert.equal(matrix.isSquare([[1,2], [3,4,5]]), false);
+    assert.equal(matrix.isSquare([[1,2,3], [4,5], [6,7,8]]), false);
     
     done();
   });


### PR DESCRIPTION
The original implementation only checked the length of the first row. You may want to consider stronger assertions in your matrix methods in general.
