### PR TITLE
Add vector addition implementation and test

### DIFF
--- a/lib/numbers/matrix.js
+++ b/lib/numbers/matrix.js
@@ -66,11 +66,18 @@ matrix.addition = function (arrA, arrB) {
   if ((arrA.length === arrB.length) && (arrA[0].length === arrB[0].length)) {
     var result = new Array(arrA.length);
     
-    for (var i = 0; i < arrA.length; i++) {
-      result[i] = new Array(arrA[i].length);
-    
-      for (var j = 0; j < arrA[i].length; j++) {
-        result[i][j] = arrA[i][j] + arrB[i][j];
+    if (!arrA[0].length) {
+      // The arrays are vectors.
+      for (var i = 0; i < arrA.length; i++) {
+        result[i] = arrA[i] + arrB[i];
+      }
+    } else {
+      for (var i = 0; i < arrA.length; i++) {
+          result[i] = new Array(arrA[i].length);
+        
+          for (var j = 0; j < arrA[i].length; j++) {
+            result[i][j] = arrA[i][j] + arrB[i][j];
+          }
       }
     }
 

--- a/test/matrix.test.js
+++ b/test/matrix.test.js
@@ -55,6 +55,18 @@ suite('numbers', function() {
     done();
   });
 
+  test('should return sum of two vectors', function(done) {
+    var arrA = [0, 1, 2];
+    var arrB = [3, 4, 5];
+
+    var arrC = [3, 5, 7];
+
+    var res = matrix.addition(arrA, arrB);
+
+    assert.deepEqual(arrC, res);
+    done();
+  });
+
   test('should returned scaled matrix', function(done) {
     var array = [
       [0, 1, 2],


### PR DESCRIPTION
numbers.matrix.addition doesn't work for vectors. In fact, the example in the README for matrix addition doesn't produce the correct result. But this change fixes that and adds a test for it!
