### PR TITLE
Bug fix for basic.gcd(a,b)

### DIFF
--- a/lib/numbers/basic.js
+++ b/lib/numbers/basic.js
@@ -145,7 +145,6 @@ basic.factorial = function (num){
 
 /**
  * Calculate the greastest common divisor amongst two integers.
- * Taken from Ratio.js https://github.com/LarryBattle/Ratio.js
  * 
  * @param {Number} number A.
  * @param {Number} number B.
@@ -153,16 +152,26 @@ basic.factorial = function (num){
  */
 basic.gcd = function (a, b) {
   var c;
-  b = (+b && +a) ? +b : 0;
-  a = b ? a : 1;
-
+  a = +a;
+  b = +b;
+  // Same as isNaN() but faster
+  if (a !== a || b !== b) {
+    return NaN;
+  }
+  //Same as !isFinite() but faster
+  if (a === Infinity || a === -Infinity || b === Infinity || b === -Infinity) {
+    return Infinity;
+  }
+  // Checks if a or b are decimals
+  if ((a % 1 !== 0) || (b % 1 !== 0)) {
+    throw new Error("Can only operate on integers");
+  }
   while (b) {
     c = a % b;
     a = b;
     b = c;
   }
-
-  return Math.abs(a);
+  return (0 < a) ? a : -a;
 };
 
 /**

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -125,7 +125,21 @@ suite('numbers', function() {
   });
 
   // basic.gcd
+  test('gcd should throw an exception when given a decimal', function (done) {
+    assert.throws(
+      function() {
+        basic.gcd(0.2,1);
+      },
+      /Can only operate on integers/
+    );
+    done();
+  });
   test('gcd should return the greatest common denominator of two integers', function (done) {
+    assert.equal(1254, basic.gcd(1254, 0));
+    assert.equal(5298, basic.gcd(0, -5298));
+    assert.equal(Infinity, basic.gcd(0, -Infinity));
+    assert.equal(Infinity, basic.gcd(4430, -Infinity));
+    assert.equal(6, basic.gcd(-1254, -5298));
     assert.equal(6, basic.gcd(1254, 5298));
     assert.equal(1, basic.gcd(78699786, 78978965));
     done();
@@ -133,6 +147,14 @@ suite('numbers', function() {
 
   // basic.lcm
   test('lcm should return the least common multiple of two integers', function (done) {
+    assert.equal(0, basic.lcm(4, 0));
+    assert.equal(0, basic.lcm(0, 4));
+    assert.equal(true, isNaN(basic.lcm(4, Infinity)));
+    assert.equal(true, isNaN(basic.lcm(Infinity, 4)));
+    assert.equal(20, basic.lcm(4, 5));
+    assert.equal(12, basic.lcm(3, 4));
+    assert.equal(12, basic.lcm(4, 6));
+    assert.equal(42, basic.lcm(21, 6));
     assert.equal(240, basic.lcm(12, 80));
     done();
   });


### PR DESCRIPTION
- Now throws an error if non-integer values are passed.
- Fixed bug. `a` is returned if `b == 0` and vice versa.
- Added more test cases for `basic.gcd()` and `basic.lcm()`

This address https://github.com/sjkaliski/numbers.js/issues/90
