### PR TITLE
[#117] Replaced Make with gulp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,0 @@
-test:
-	@./node_modules/.bin/mocha -u tdd
-.PHONY: test
-
-build:
-	browserify ./lib/numbers.js -o ./src/numbers.js
-	uglifyjs -o ./src/numbers.min.js ./src/numbers.js

--- a/README.md
+++ b/README.md
@@ -98,13 +98,30 @@ To execute, run:
 ```
 npm test
 ```
+Note: Make sure to install the plugins by running `npm install`.
+
+## Lint
+
+To perform a code quality check using jshint, run 
+
+```
+npm run lint
+```
+
+## Format Code
+
+To format all the tests and lib files using jsbeautifier, run 
+
+```
+npm run format
+```
 
 ## Build
 
 To update the public JavaScript, run
 
 ```
-make build
+npm run build
 ```
 
 This will compile the entire library into a single file accessible at src/numbers.js. It will also minify the file into public/numbers.min.js.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,65 @@
+var browserify = require("browserify");
+var buffer = require("vinyl-buffer");
+var del = require("del");
+var gulp = require("gulp");
+var jshint = require("gulp-jshint");
+var jshintStylish = require("jshint-stylish");
+var mocha = require("gulp-mocha");
+var prettify = require("gulp-jsbeautifier");
+var rename = require("gulp-rename");
+var source = require("vinyl-source-stream");
+var uglify = require("gulp-uglify");
+
+var DEST = "./src";
+
+gulp.task("build", [ "minimize" ]);
+
+gulp.task("clean:src", function(cb){
+  del([
+    DEST
+  ], cb );
+});
+
+gulp.task("concat", [ "clean:src" ], function(){
+  return browserify("./index.js", { standalone : "numbers" })
+    .bundle()
+    .pipe(source("numbers.js"))
+    .pipe(gulp.dest( DEST ));
+});
+
+gulp.task("default", [ "build" ]);
+
+gulp.task("format:lib", function(){
+  return gulp.src( ["./lib/**/*.js"], { base : "./lib"} )
+    .pipe(prettify())
+    .pipe(gulp.dest("./lib"));
+});
+
+gulp.task("format:test", function(){
+  return gulp.src( ["./test/*.js"], { base : "./"} )
+    .pipe(prettify())
+    .pipe(gulp.dest("./"));
+});
+
+gulp.task("format", [ "format:lib", "format:test" ]);
+
+gulp.task("lint", function(){
+  return gulp.src( ["./lib/**/*.js", "./test/*.js"] )
+    .pipe(jshint())
+    .pipe(jshint.reporter(jshintStylish));
+});
+
+gulp.task("minimize", [ "concat" ], function(){
+  return gulp.src( DEST + "/numbers.js")
+    .pipe(uglify())
+    .pipe(rename({ extname : ".min.js" }))
+    .pipe(gulp.dest( DEST ));
+});
+
+gulp.task("test", function(){
+  return gulp.src(["./test/*.js", "!./test/testing.js"])
+    .pipe(mocha({ 
+       ui : "tdd"
+     }));
+});
+

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "David Byrd (https://github.com/davidbyrd11)",
     "Ethan Resnick (https://github.comc/ethanresnick)",
     "Dakota St. Laurent (https://github.com/StDako)",
-    "Kartik Talwar (https://github.com/KartikTalwar)"
+    "Kartik Talwar (https://github.com/KartikTalwar)",
+    "Larry Battle (https://github.com/LarryBattle)"
   ],
   "engines": {
     "node": ">= v0.6.0"
@@ -25,12 +26,24 @@
     "statistics"
   ],
   "devDependencies": {
+    "browserify": "~5.12.1",
+    "del": "~0.1.3",
+    "gulp": "~3.8.8",
+    "gulp-jsbeautifier": "0.0.2",
+    "gulp-jshint": "~1.8.4",
+    "gulp-mocha": "~1.1.0",
+    "gulp-rename": "~1.2.0",
+    "gulp-uglify": "~1.0.1",
+    "jshint-stylish": "~1.0.0",
     "mocha": "~1.8.0",
-    "browserify": "~1.16.6",
-    "uglify-js": "~2.2.2"
+    "uglify-js": "~2.2.2",
+    "vinyl-buffer": "~1.0.0",
+    "vinyl-source-stream": "~1.0.0"
   },
   "scripts": {
-    "test": "make test",
-    "build": "make build"
+    "build": "gulp build",
+    "format": "gulp format",
+    "lint": "gulp lint",
+    "test": "gulp test"
   }
 }


### PR DESCRIPTION
Replaced Make with gulp.
The following build options are now available.
- `npm run build` - uses browserify to consolidate all js files in `./lib` and creates a `numbers.js` and `numbers.min.js` in `./src`.
- `npm run format` - uses jsbeautifier to format all js files in `./lib` and `./test`
- `npm run lint` - run jshint against code in `./lib` and `./test`
- `npm run test` - run test cases in `./test` using mocha.

Reference: https://github.com/sjkaliski/numbers.js/issues/117
