### PR TITLE
fix #140, add matrix.map

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ $ bower install numbers.js
 * Steve Kaliski - [@stevekaliski](http://twitter.com/stevekaliski)
 * David Byrd - [@thebyrd](http://twitter.com/thebyrd)
 * Ethan Resnick - [@studip101](http://twitter.com/studip101)
-* Dakota St. Laurent - [@StDako](https://github.com/StDako)
+* Dakota St. Laurent - [@SaintDako](https://github.com/SaintDako)
 * Kartik Talwar - [@KartikTalwar](https://github.com/KartikTalwar)
 
 ## Contributors

--- a/lib/numbers/matrix.js
+++ b/lib/numbers/matrix.js
@@ -1289,3 +1289,27 @@ matrix.isStrictlyColumnDD = function (M) {
   }
   return true;
 };
+
+/**
+ * Applies a function to every element of a vector or matrix.
+ * The function must take only one parameter.
+ *
+ * @param {Array} matrix
+ * @param {Function} function to apply to each element
+ * @return {Array} matrix operated on
+ */
+matrix.applyFunction = function (M, f) {
+  // M is n-by-m (n rows, m columns)
+  var n = M.length,
+      m = M[0].length,
+      i, j;
+
+  var res = matrix.deepCopy(M);
+
+  for (i=0; i<n; i++) {
+    for (j=0; j<m; j++) {
+      res[i][j] = f(M[i][j]);
+    }
+  }
+  return res;
+}

--- a/lib/numbers/matrix.js
+++ b/lib/numbers/matrix.js
@@ -152,13 +152,14 @@ matrix.subtraction = function (arrA, arrB) {
  * @return {Array} updated matrix.
  */
 matrix.scalar = function (arr, val) {
-  for (var i = 0; i < arr.length; i++) {
-    for (var j = 0; j < arr[i].length; j++) {
-      arr[i][j] = val * arr[i][j];
+  var result = matrix.deepCopy(arr);
+  for (var i = 0; i < result.length; i++) {
+    for (var j = 0; j < result[i].length; j++) {
+      result[i][j] = val * arr[i][j];
     }
   }
 
-  return arr;
+  return result;
 };
 
 /**

--- a/lib/numbers/matrix.js
+++ b/lib/numbers/matrix.js
@@ -1291,14 +1291,14 @@ matrix.isStrictlyColumnDD = function (M) {
 };
 
 /**
- * Applies a function to every element of a vector or matrix.
+ * Applies a function to every element of a vector or matrix (i.e. map).
  * The function must take only one parameter.
  *
  * @param {Array} matrix
  * @param {Function} function to apply to each element
  * @return {Array} matrix operated on
  */
-matrix.applyFunction = function (M, f) {
+matrix.map = function (M, f) {
   // M is n-by-m (n rows, m columns)
   var n = M.length,
       m = M[0].length,

--- a/test/matrix.test.js
+++ b/test/matrix.test.js
@@ -915,4 +915,38 @@ suite('numbers', function () {
     done();
   });
 
+  test('should test for applying a function to each element of a matrix', function (done) {
+    var m1 = [
+      [-1, 0, 5],
+      [2, 3, 18],
+      [42, 0, 3]
+    ];
+    var m2 = [
+      [-5, 2],
+      [2, 3],
+      [11, -1]
+    ];
+    var addOne = function(x) {
+      return x + 1;
+    }
+
+    var expected1 = [
+      [0, 1, 6],
+      [3, 4, 19],
+      [43, 1, 4]
+    ];
+    var expected2 = [
+      [-4, 3],
+      [3, 4],
+      [12, 0]
+    ];
+
+    var res1 = matrix.applyFunction(m1, addOne);
+    var res2 = matrix.applyFunction(m2, addOne);
+
+    assert.deepEqual(res1, expected1);
+    assert.deepEqual(res2, expected2);
+    done();
+  });
+
 });

--- a/test/matrix.test.js
+++ b/test/matrix.test.js
@@ -941,8 +941,8 @@ suite('numbers', function () {
       [12, 0]
     ];
 
-    var res1 = matrix.applyFunction(m1, addOne);
-    var res2 = matrix.applyFunction(m2, addOne);
+    var res1 = matrix.map(m1, addOne);
+    var res2 = matrix.map(m2, addOne);
 
     assert.deepEqual(res1, expected1);
     assert.deepEqual(res2, expected2);


### PR DESCRIPTION
#140 wasn't broken, per se, but an in-place operation is deceiving. as mentioned in that issue, it would be nice to have a separate function for an in-place operation, in case it's needed. perhaps a suffix of `IP` would be suitable.

`matrix.map` takes a matrix (or vector) and applies a function to every element to a copy of the matrix (not in-place!). the purpose behind this function is to imitate how some of Numpy's functions operate element-by-element on Numpy arrays. so instead of writing `matrix.sin`, `matrix.cos`... etc. the user can just pass any function to `matrix.map`.

the catch: the function passed can only take one parameter, so it would be nice (and pretty simple, methinks) to create something that would behave like so:

```
f = function(x, a, b) {
  return a*x + b;
}
var m = [[1,2,3],[4,5,6]];

var m2 = matrix.mapNEW(m, f, a, b);
```

so that any additional parameters passed to `matrix.mapNEW` (name is a work in progress) are passed to `f` too.
